### PR TITLE
Fixes mardown links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,19 @@ To install pyAudio on windows use:
 for other platform
 > pip install pyaudio
 
-- **Kivy:** [https://kivy.org/#home](https://kivy.org/#home)
+- **Kivy:** <https://kivy.org/#home>
 
-- **KivyMD:** [https://github.com/HeaTTheatR/KivyMD](KivyMD, Version 0.100.2)
+- **KivyMD:** [KivyMD, Version 0.100.2](https://github.com/HeaTTheatR/KivyMD)
 
 
 ## Useful links
 
-- **Code Jam Rules:** [https://pythondiscord.com/pages/code-jams/code-jam-6/rules/](https://pythondiscord.com/pages/code-jams/code-jam-6/rules/)
+- **Code Jam Rules:** <https://pythondiscord.com/pages/code-jams/code-jam-6/rules/>
 
-- **General Code Jam info:** [https://pythondiscord.com/pages/code-jams/code-jam-6/](https://pythondiscord.com/pages/code-jams/code-jam-6/)
+- **General Code Jam info:** <https://pythondiscord.com/pages/code-jams/code-jam-6/>
 
-- **Kivy:** [https://kivy.org/#home](https://kivy.org/#home)
+- **Kivy:** <https://kivy.org/#home>
 
 ## License
 
-All projects will merged into our Code Jam repository, which uses the [MIT license](../LICENSE). Please make sure that if you add assets, the licenses of those assets are compatible with the MIT license.
+All projects will merged into our Code Jam repository, which uses the [MIT license](LICENSE). Please make sure that if you add assets, the licenses of those assets are compatible with the MIT license.


### PR DESCRIPTION
Specifically the KivyMD link was completely off because of the inverted target and anchor syntax.
Also simplified links where anchor text is same as target using the `<>` shortcut.